### PR TITLE
Add orchestration support for GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ hs_err_pid*
 *.iml
 *.iws
 
+# VSCode
+.vscode/
+
 # Mac
 .DS_Store
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM maven:3.6-jdk-8 as builder
+
+COPY benchmark /workspace
+
+WORKDIR /workspace
+
+RUN mvn package
+
+FROM openjdk:11.0-jre
+
+WORKDIR /rabbittesttool
+
+COPY --from=builder \
+    /workspace/target/rabbittesttool-1.0-SNAPSHOT-jar-with-dependencies.jar \
+    rabbittesttool.jar
+
+COPY benchmark/topologies topologies
+COPY benchmark/policies policies

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,16 @@ build: $(DOCKER) ## b  | Build JAR
 .PHONY: b
 b: build
 
+.PHONY: docker-image
+docker-image: $(DOCKER)
+	@docker build \
+	  --tag vanlightly/rabbittesttool:latest \
+	  .
+
+.PHONY: test-docker-image
+test-docker-image:
+	@docker run -it --rm vanlightly/rabbittesttool:latest help
+
 .PHONY: help
 help:
 	@awk -F"[:#]" '/^[^\.][a-zA-Z\._\-]+:+.+##.+$$/ { printf "\033[36m%-24s\033[0m %s\n", $$1, $$4 }' $(MAKEFILE_LIST) \

--- a/benchmark/src/sql/tables.sql
+++ b/benchmark/src/sql/tables.sql
@@ -10,7 +10,7 @@ create table benchmark
 	description varchar(1000) not null,
 	run_tag varchar(10) not null,
 	config_tag varchar(50) not null,
-	node varchar(50) not null,
+	node varchar(100) not null,
 	technology varchar(100) not null,
 	broker_version varchar(50) not null,
 	instance varchar(100) not null,

--- a/orchestration/run/AwsBrokerActions.py
+++ b/orchestration/run/AwsBrokerActions.py
@@ -1,0 +1,32 @@
+import sys
+import io
+import subprocess
+import threading
+import time
+import uuid
+import os.path
+import requests
+import json
+from random import randint
+from BrokerActions import BrokerActions
+from UniqueConfiguration import UniqueConfiguration
+from CommonConfiguration import CommonConfiguration
+from printer import console_out
+
+class AwsBrokerActions(BrokerActions):
+    def __init__(self, deployer):
+        super().__init__(deployer)
+
+    def restart_broker(self, technology, node, common_conf):
+        status_id = technology + node
+        exit_code = subprocess.call(["bash", "restart-broker.sh",
+                                     common_conf.key_pair,
+                                     node,
+                                     common_conf.run_tag,
+                                     technology])
+        
+        if exit_code != 0:
+            console_out(self.actor, f"Restart of broker on node {node} failed with exit code {exit_code}")
+            self._action_status[status_id] = "failed"   
+        else:
+            self._action_status[status_id] = "success"

--- a/orchestration/run/AwsCommonConfiguration.py
+++ b/orchestration/run/AwsCommonConfiguration.py
@@ -1,0 +1,16 @@
+import uuid
+from CommonConfiguration import CommonConfiguration
+from command_args import get_args, get_optional_arg, get_mandatory_arg, get_mandatory_arg_no_print, is_true, get_mandatory_arg_validated, get_optional_arg_validated
+
+class AwsCommonConfiguration(CommonConfiguration):
+
+    def __init__(self, args):
+        super().__init__(args)
+
+        self.ami = get_mandatory_arg(args, "--ami", "")
+        self.broker_sg = get_mandatory_arg(args, "--broker-sg", "")
+        self.loadgen_sg = get_mandatory_arg(args, "--loadgen-sg", "")
+        self.loadgen_instance = get_mandatory_arg(args, "--loadgen-instance", "")
+        self.subnet = get_mandatory_arg(args, "--subnet", "")
+        self.key_pair = get_mandatory_arg(args, "--keypair", "")
+        self.hosting = "aws"

--- a/orchestration/run/AwsDeployer.py
+++ b/orchestration/run/AwsDeployer.py
@@ -1,0 +1,196 @@
+import sys
+import subprocess
+import threading
+import time
+import uuid
+import os.path
+from datetime import datetime
+from random import randint
+from Deployer import Deployer
+from UniqueConfiguration import UniqueConfiguration
+from CommonConfiguration import CommonConfiguration
+from printer import console_out, console_out_exception
+
+class AwsDeployer(Deployer):
+    def __init__(self):
+        super().__init__()
+
+    def update_single(self, unique_conf, common_conf):
+        status_id = unique_conf.technology + unique_conf.node_number
+        exit_code = subprocess.call(["bash", "update-benchmark.sh", 
+                        common_conf.key_pair, 
+                        unique_conf.node_number, 
+                        unique_conf.technology, 
+                        common_conf.run_tag], cwd="../deploy/aws")
+        if exit_code != 0:
+            console_out(self.actor, f"update {unique_conf.node_number} failed with exit code {exit_code}")
+            self._deploy_status[status_id] = "failed"   
+        else:
+            self._deploy_status[status_id] = "success"
+
+    def deploy_single(self, unique_conf, common_conf):
+        status_id = unique_conf.technology + unique_conf.node_number
+        self._deploy_status[status_id] = "started"
+        volume_type = unique_conf.volume.split("-")[1]
+        exit_code = subprocess.call(["bash", "deploy-single-broker.sh", 
+                            common_conf.ami, 
+                            unique_conf.broker_version, 
+                            unique_conf.core_count,
+                            unique_conf.filesystem, 
+                            unique_conf.generic_unix_url,
+                            unique_conf.instance, 
+                            common_conf.key_pair, 
+                            common_conf.loadgen_instance, 
+                            common_conf.loadgen_sg, 
+                            common_conf.log_level,
+                            unique_conf.node_number, 
+                            common_conf.run_tag, 
+                            common_conf.broker_sg, 
+                            common_conf.subnet, 
+                            unique_conf.technology, 
+                            unique_conf.tenancy, 
+                            unique_conf.threads_per_core, 
+                            unique_conf.vars_file, 
+                            unique_conf.volume_size, 
+                            volume_type], cwd="../deploy/aws")
+
+        if exit_code != 0:
+            console_out(self.actor, f"deploy {unique_conf.node_number} failed with exit code {exit_code}")
+            self._deploy_status[status_id] = "failed"   
+        else:
+            self._deploy_status[status_id] = "success"
+
+    def deploy_rabbitmq_cluster(self, unique_conf, common_conf):
+        status_id = unique_conf.technology + unique_conf.node_number
+        self._deploy_status[status_id] = "started"
+        volume_type = unique_conf.volume.split("-")[1]
+        
+        exit_code = subprocess.call(["bash", "deploy-rmq-cluster-instances.sh", 
+                                common_conf.ami, 
+                                str(unique_conf.cluster_size), 
+                                unique_conf.core_count, 
+                                unique_conf.instance, 
+                                common_conf.key_pair, 
+                                common_conf.loadgen_instance, 
+                                common_conf.loadgen_sg, 
+                                unique_conf.node_number, 
+                                common_conf.run_tag, 
+                                common_conf.broker_sg, 
+                                common_conf.subnet, 
+                                unique_conf.tenancy, 
+                                unique_conf.threads_per_core, 
+                                unique_conf.volume_size, 
+                                volume_type], cwd="../deploy/aws")
+        if exit_code != 0:
+            console_out(self.actor, f"deploy {unique_conf.node_number} failed with exit code {exit_code}")
+            self._deploy_status[status_id] = "failed" 
+            return  
+        
+        master_node = int(unique_conf.node_number)
+        node_range_start = master_node
+        node_range_end = master_node + int(unique_conf.cluster_size) - 1
+        
+        # deploy master
+        exit_code = subprocess.call(["bash", "deploy-rmq-cluster-broker.sh", 
+                                common_conf.ami, 
+                                unique_conf.broker_version, 
+                                unique_conf.core_count, 
+                                unique_conf.filesystem, 
+                                unique_conf.generic_unix_url,
+                                unique_conf.instance, 
+                                common_conf.key_pair, 
+                                common_conf.log_level,
+                                str(master_node), 
+                                str(node_range_end), 
+                                str(node_range_start), 
+                                "master", 
+                                common_conf.run_tag, 
+                                common_conf.broker_sg, 
+                                common_conf.subnet, 
+                                unique_conf.tenancy, 
+                                unique_conf.threads_per_core, 
+                                unique_conf.vars_file, 
+                                unique_conf.volume_size, 
+                                volume_type], cwd="../deploy/aws")
+
+        if exit_code != 0:
+            console_out(self.actor, f"deploy {unique_conf.node_number} failed with exit code {exit_code}")
+            self._deploy_status[status_id] = "failed"   
+            return
+
+        # deploy joinees
+        joinee_threads = list()
+        for node in range(node_range_start+1, node_range_end+1):
+            deploy = threading.Thread(target=self.deploy_joinee, args=(unique_conf, common_conf, status_id, volume_type, node, node_range_start, node_range_end))
+            joinee_threads.append(deploy)
+
+        for jt in joinee_threads:
+            jt.start()
+        
+        for jt in joinee_threads:
+            jt.join()
+
+        # deploy benchmark
+        if self._deploy_status[status_id] != "failed":
+            exit_code = subprocess.call(["bash", "deploy-benchmark.sh", 
+                                common_conf.key_pair, 
+                                str(master_node), 
+                                "rabbitmq", 
+                                common_conf.run_tag], cwd="../deploy/aws")
+
+            if exit_code != 0:
+                console_out(self.actor, f"deploy {unique_conf.node_number} failed with exit code {exit_code}")
+                self._deploy_status[status_id] = "failed"   
+            else:
+                self._deploy_status[status_id] = "success"
+    
+    
+
+    def deploy_joinee(self, unique_conf, common_conf, status_id, volume_type, node, node_range_start, node_range_end):
+        exit_code = subprocess.call(["bash", "deploy-rmq-cluster-broker.sh", 
+                                common_conf.ami, 
+                                unique_conf.broker_version, 
+                                unique_conf.core_count, 
+                                unique_conf.filesystem, 
+                                unique_conf.generic_unix_url,
+                                unique_conf.instance, 
+                                common_conf.key_pair, 
+                                common_conf.log_level,
+                                str(node), 
+                                str(node_range_end), 
+                                str(node_range_start), 
+                                "joinee", 
+                                common_conf.run_tag, 
+                                common_conf.broker_sg, 
+                                common_conf.subnet, 
+                                unique_conf.tenancy, 
+                                unique_conf.threads_per_core, 
+                                unique_conf.vars_file, 
+                                unique_conf.volume_size, 
+                                volume_type], cwd="../deploy/aws")    
+        if exit_code != 0:
+            console_out(self.actor, f"deploy of joinee rabbitmq{node} failed with exit code {exit_code}")
+            self._deploy_status[status_id] = "failed"   
+    
+    def teardown(self, technology, node, run_tag, no_destroy):
+        if no_destroy:
+            console_out(self.actor, "No teardown as --no-destroy set to true")
+        else:
+            terminated = False
+            while not terminated:
+                exit_code = subprocess.call(["bash", "terminate-instances.sh", technology, node, run_tag], cwd="../deploy/aws")
+                if exit_code == 0:
+                    terminated = True
+                else:
+                    console_out(self.actor, "teardown failed, will retry in 1 minute")
+                    time.sleep(60)
+
+    def get_logs(self, common_conf, start_node, end_node):
+        target_dir = "logs/" + datetime.now().strftime("%Y%m%d%H%M")
+        subprocess.call(["bash", "get-logs.sh",
+                        common_conf.key_pair,
+                        str(start_node),
+                        str(end_node),
+                        str(common_conf.run_tag),
+                        "rabbitmq",
+                        target_dir ])

--- a/orchestration/run/AwsRunner.py
+++ b/orchestration/run/AwsRunner.py
@@ -1,0 +1,108 @@
+import sys
+import subprocess
+import threading
+import time
+import uuid
+import os.path
+from random import randint
+from collections import namedtuple
+from printer import console_out
+from Runner import Runner
+
+class AwsRunner(Runner):
+    def __init__(self):
+        super().__init__()
+
+    def run_benchmark(self, unique_conf, common_conf, playlist_entry, policies, run_ordinal):
+        status_id = unique_conf.technology + unique_conf.node_number
+
+        nodes = ""
+        for x in range(int(unique_conf.cluster_size)):
+            comma = ","
+            if x == 0:
+                comma = ""
+
+            node_number = int(unique_conf.node_number) + x
+            nodes = f"{nodes}{comma}rabbit@rabbitmq{node_number}"
+
+        self._benchmark_status[status_id] = "started"
+        exit_code = subprocess.call(["bash", "run-logged-aws-benchmark.sh", 
+                                unique_conf.node_number, 
+                                common_conf.key_pair, 
+                                unique_conf.technology, 
+                                unique_conf.broker_version, 
+                                unique_conf.instance, 
+                                unique_conf.volume, 
+                                unique_conf.filesystem, 
+                                common_conf.hosting, 
+                                unique_conf.tenancy, 
+                                common_conf.password, 
+                                common_conf.postgres_url, 
+                                common_conf.postgres_user, 
+                                common_conf.postgres_pwd, 
+                                playlist_entry.topology, 
+                                common_conf.run_id, 
+                                common_conf.username, 
+                                common_conf.password, 
+                                common_conf.run_tag, 
+                                unique_conf.core_count, 
+                                unique_conf.threads_per_core, 
+                                unique_conf.config_tag, 
+                                str(unique_conf.cluster_size), 
+                                unique_conf.no_tcp_delay, 
+                                policies, 
+                                str(common_conf.override_step_seconds), 
+                                str(common_conf.override_step_repeat), 
+                                nodes, 
+                                str(common_conf.override_step_msg_limit), 
+                                common_conf.override_broker_hosts, 
+                                unique_conf.pub_connect_to_node,
+                                unique_conf.con_connect_to_node,
+                                common_conf.mode,
+                                str(playlist_entry.grace_period_sec),
+                                str(run_ordinal),
+                                common_conf.tags,
+                                playlist_entry.get_topology_variables(),
+                                playlist_entry.get_policy_variables()])
+
+        if exit_code != 0:
+            console_out(self.actor, f"Benchmark {unique_conf.node_number} failed")
+            self._benchmark_status[status_id] = "failed"
+        else:
+            self._benchmark_status[status_id] = "success"
+
+    def run_background_load(self, unique_conf, common_conf):
+        console_out(self.actor, f"Starting background load for {unique_conf.node_number}")
+        status_id = unique_conf.technology + unique_conf.node_number
+
+        broker_user = "benchmark"
+        broker_password = common_conf.password
+        topology = common_conf.background_topology_file
+        policies = common_conf.background_policies_file
+        step_seconds = str(common_conf.background_step_seconds)
+        step_repeat = str(common_conf.background_step_repeat)
+
+        nodes = ""
+        for x in range(int(unique_conf.cluster_size)):
+            comma = ","
+            if x == 0:
+                comma = ""
+
+            node_number = int(unique_conf.node_number) + x
+            nodes = f"{nodes}{comma}{node_number}"
+
+        self._benchmark_status[status_id] = "started"
+        subprocess.Popen(["bash", "run-background-load-aws.sh", 
+                        broker_user, 
+                        broker_password, 
+                        str(unique_conf.cluster_size), 
+                        common_conf.key_pair, 
+                        unique_conf.node_number, 
+                        nodes, 
+                        policies, 
+                        step_seconds, 
+                        step_repeat, 
+                        common_conf.run_tag, 
+                        unique_conf.technology, 
+                        topology, 
+                        unique_conf.broker_version])

--- a/orchestration/run/AwsUniqueConfiguration.py
+++ b/orchestration/run/AwsUniqueConfiguration.py
@@ -1,0 +1,10 @@
+from UniqueConfiguration import UniqueConfiguration
+from command_args import get_args, get_optional_arg, get_mandatory_arg, get_mandatory_arg_no_print, is_true, get_mandatory_arg_validated, get_optional_arg_validated
+
+class AwsUniqueConfiguration(UniqueConfiguration):
+    def __init__(self, args, suffix):
+        super().__init__(args, suffix)
+
+        self.generic_unix_url = get_mandatory_arg(args, "--generic-unix-url", self.suffix)
+        self.instance = get_mandatory_arg(args, "--instance", self.suffix)
+        self.volume = get_mandatory_arg_validated(args, "--volume", self.suffix, ["ebs-io1","ebs-st1","ebs-gp2","local-nvme"])

--- a/orchestration/run/BrokerActions.py
+++ b/orchestration/run/BrokerActions.py
@@ -46,7 +46,7 @@ class BrokerActions:
                 # iterate over nodes of this configuration
                 for n in range(unique_conf.cluster_size):
                     node = int(unique_conf.node_number) + n
-                    restart = threading.Thread(target=self.restart_broker, args=(unique_conf.technology, str(node), common_conf.run_tag, common_conf.key_pair,))
+                    restart = threading.Thread(target=self.restart_broker, args=(unique_conf.technology, str(node), common_conf))
                     r_threads.append(restart)
 
         for rt in r_threads:
@@ -67,7 +67,7 @@ class BrokerActions:
                     if self._action_status[status_id] != "success":
                         console_out(self.actor, f"Broker restart failed for node {unique_conf.technology}{node}")
                         if not common_conf.no_deploy:
-                            self._deployer.teardown_all(configurations, common_conf.run_tag, False)
+                            self._deployer.teardown_all(configurations, common_conf, False)
 
     def restart_one_broker(self, configurations, common_conf):
         r_threads = list()
@@ -77,7 +77,7 @@ class BrokerActions:
             # iterate over configurations
             for p in range(len(unique_conf_list)):
                 unique_conf = unique_conf_list[p]
-                restart = threading.Thread(target=self.restart_broker, args=(unique_conf.technology, str(unique_conf.node_number), common_conf.run_tag, common_conf.key_pair,))
+                restart = threading.Thread(target=self.restart_broker, args=(unique_conf.technology, str(unique_conf.node_number), common_conf))
                 r_threads.append(restart)
 
         for rt in r_threads:
@@ -95,7 +95,7 @@ class BrokerActions:
                 if self._action_status[status_id] != "success":
                     console_out(self.actor, f"Broker restart failed for node {unique_conf.technology}{unique_conf.node_number}")
                     if not common_conf.no_deploy:
-                        self._deployer.teardown_all(configurations, common_conf.run_tag, False)
+                        self._deployer.teardown_all(configurations, common_conf, False)
                 
 
     def restart_broker(self, technology, node, run_tag, key_pair):

--- a/orchestration/run/CommonConfiguration.py
+++ b/orchestration/run/CommonConfiguration.py
@@ -26,17 +26,10 @@ class CommonConfiguration:
         self.override_step_msg_limit = int(get_optional_arg(args, "--override-step-msg-limit", "", "0"))
         self.override_broker_hosts = get_optional_arg(args, "--override-broker-hosts", "", "")
 
-        self.ami = get_mandatory_arg(args, "--ami", "")
-        self.broker_sg = get_mandatory_arg(args, "--broker-sg", "")
-        self.loadgen_sg = get_mandatory_arg(args, "--loadgen-sg", "")
-        self.loadgen_instance = get_mandatory_arg(args, "--loadgen-instance", "")
-        self.subnet = get_mandatory_arg(args, "--subnet", "")
-        self.key_pair = get_mandatory_arg(args, "--keypair", "")
         self.username = "benchmark"
         self.password = get_mandatory_arg(args, "--password", "")
         self.postgres_url = get_mandatory_arg(args, "--postgres-jdbc-url", "")
         self.postgres_user = get_mandatory_arg(args, "--postgres-user", "")
         self.postgres_pwd = get_mandatory_arg_no_print(args, "--postgres-password", "")
         self.node_counter = int(get_optional_arg(args, "--start-node-num-from", "", "1"))
-        self.hosting = "aws"
         self.log_level = get_optional_arg(args, "--log-level", "", "info")

--- a/orchestration/run/GcpBrokerActions.py
+++ b/orchestration/run/GcpBrokerActions.py
@@ -1,0 +1,38 @@
+import subprocess
+
+from BrokerActions import BrokerActions
+from printer import console_out
+
+
+class GcpBrokerActions(BrokerActions):
+    def __init__(self, deployer):
+        super().__init__(deployer)
+
+    def restart_broker(self, technology, node, common_conf):
+        status_id = technology + node
+
+        node_name = f"{common_conf.run_tag}-rmq{node}-server"
+
+        command_args = ["gcloud", "compute", "ssh",
+                        node_name,
+                        "--",
+                        "docker exec $(docker container ls | awk '/rabbitmq/ { print $1 }') rabbitmqctl -l stop_app"]
+        result = subprocess.run(command_args)
+
+        if result.returncode != 0:
+            console_out(self.actor, f"Restart (1/2) of broker on node {node} failed with exit code {result.returncode}")
+            self._action_status[status_id] = "failed"
+            return
+
+        command_args = ["gcloud", "compute", "ssh",
+                        node_name,
+                        "--",
+                        "docker restart --time 30 $(docker container ls | awk '/rabbitmq/ { print $1 }')"]
+        result = subprocess.run(command_args)
+
+        if result.returncode != 0:
+            console_out(self.actor, f"Restart (2/2) of broker on node {node} failed with exit code {result.returncode}")
+            self._action_status[status_id] = "failed"
+            return
+
+        self._action_status[status_id] = "success"

--- a/orchestration/run/GcpCommonConfiguration.py
+++ b/orchestration/run/GcpCommonConfiguration.py
@@ -1,0 +1,14 @@
+import uuid
+from CommonConfiguration import CommonConfiguration
+from command_args import get_args, get_optional_arg, get_mandatory_arg, get_mandatory_arg_no_print, is_true, get_mandatory_arg_validated, get_optional_arg_validated
+
+class GcpCommonConfiguration(CommonConfiguration):
+
+    def __init__(self, args):
+        super().__init__(args)
+
+        self.gcp_project_id = get_mandatory_arg(args, "--gcp-project-id", "")
+        self.gcp_postgres_connection_name = get_optional_arg(args, "--gcp-postgres-connection-name", "", "")
+        self.loadgen_machine_type = get_mandatory_arg(args, "--loadgen-machine-type", "")
+        self.loadgen_container_image = get_mandatory_arg(args, "--loadgen-container-image", "")
+        self.hosting = "gcp"

--- a/orchestration/run/GcpDeployer.py
+++ b/orchestration/run/GcpDeployer.py
@@ -1,0 +1,237 @@
+import subprocess
+import json
+import re
+import subprocess
+import time
+
+from Deployer import Deployer
+from printer import console_out
+
+
+class GcpDeployer(Deployer):
+    def __init__(self):
+        super().__init__()
+
+    def update_single(self, unique_conf, common_conf):
+        status_id = unique_conf.technology + unique_conf.node_number
+
+        node_name = f"{common_conf.run_tag}-{unique_conf.suffix}-loadgen"
+
+        console_out(self.actor, f"Updating node {node_name}...")
+
+        command_args = ["gcloud", "compute", "instances", "update-container",
+                        node_name,
+                        f"--container-image='{common_conf.loadgen_container_image}'"]
+
+        exit_code = subprocess.call(command_args)
+
+        if exit_code != 0:
+            console_out(self.actor, f"deploy {node_name} failed with exit code {exit_code}")
+            self._deploy_status[status_id] = "failed"
+            return
+
+        console_out(self.actor, f"Waiting 1 minute to let the loadgen instance start...")
+        time.sleep(60)
+
+        self._deploy_status[status_id] = "success"
+
+    def deploy_single(self, unique_conf, common_conf):
+        self.deploy_rabbitmq_cluster(unique_conf, common_conf)
+
+    def deploy_rabbitmq_cluster(self, unique_conf, common_conf):
+        if re.match(r'^\d', common_conf.run_tag):
+            common_conf.run_tag = "rtt-" + common_conf.run_tag
+
+        status_id = unique_conf.technology + unique_conf.node_number
+        self._deploy_status[status_id] = "started"
+
+        first_node_number = int(unique_conf.node_number)
+        cluster_size = int(unique_conf.cluster_size)
+
+        try:
+            # deploy unclustered nodes
+            for node in range(first_node_number, first_node_number + cluster_size):
+                node_name = f"{common_conf.run_tag}-rmq{node}-server"
+                if self.__node_exists(node_name):
+                    console_out(self.actor, f"{node_name} already exists, skipping deploy")
+                    continue
+
+                self.__deploy_rmq_node(node_name, common_conf, unique_conf)
+
+            # wait for nodes to be ready
+            for node in range(first_node_number, first_node_number + cluster_size):
+                node_name = f"{common_conf.run_tag}-rmq{node}-server"
+                self.__wait_rabbitmq_ready(node_name)
+
+            # form the cluster
+            master_node = f"rabbit@{common_conf.run_tag}-rmq{first_node_number}-server.c.{common_conf.gcp_project_id}.internal"
+            for node in range(first_node_number + 1, first_node_number + cluster_size):
+                node_name = f"{common_conf.run_tag}-rmq{node}-server"
+                for command in ["stop_app", "reset", f"join_cluster {master_node}", "start_app"]:
+                    command_args = ["gcloud", "compute", "ssh",
+                                    node_name,
+                                    "--",
+                                    "docker exec $(docker container ls | awk '/rabbitmq/ { print $1 }') "
+                                    "rabbitmqctl -l " + command]
+                    exit_code = subprocess.call(command_args)
+                    if exit_code != 0:
+                        raise Exception(f"rabbitmqctl {command} on {node_name} failed with exit code {exit_code}")
+
+            # deploy benchmark
+            node_name = f"{common_conf.run_tag}-{unique_conf.suffix}-loadgen"
+            if not self.__node_exists(node_name):
+                self.__deploy_loadgen_node(node_name, common_conf)
+            else:
+                console_out(self.actor, f"{node_name} already exists, skipping deploy")
+            self._deploy_status[status_id] = "success"
+
+        except Exception as e:
+            console_out(self.actor, e)
+            self._deploy_status[status_id] = "failed"
+
+    def teardown(self, technology, node, run_tag, no_destroy):
+        if no_destroy:
+            console_out(self.actor, "No teardown as --no-destroy set to true")
+        else:
+            try:
+                self.__delete_instance(f"{run_tag}-rmq{node}-server")
+            except Exception as e:
+                console_out(self.actor, f"{e}, ignoring")
+
+    def teardown_loadgen(self, unique_conf, common_conf, no_destroy):
+        if no_destroy:
+            console_out(self.actor, "No teardown as --no-destroy set to true")
+        else:
+            try:
+                self.__delete_instance(f"{common_conf.run_tag}-{unique_conf.suffix}-loadgen")
+            except Exception as e:
+                console_out(self.actor, f"{e}, ignoring")
+
+    def get_logs(self, common_conf, start_node, end_node):
+        # https://cloud.google.com/compute/docs/containers/deploying-containers#viewing_container_logs
+        raise NotImplementedError
+
+    def __delete_instance(self, name, attempts = 5):
+        command_args = ["gcloud", "compute", "instances", "delete",
+                        name,
+                        "--quiet"]
+        exit_code = subprocess.call(command_args)
+        if exit_code == 0:
+            return
+        if attempts - 1 == 0:
+            raise Exception(f"teardown of {name} failed after 5 attempts")
+        console_out(self.actor, "teardown failed, will retry in 1 minute")
+        time.sleep(60)
+        self.__delete_instance(name, attempts - 1)
+
+    def __node_exists(self, node_name):
+        search_args = ["gcloud", "compute", "instances", "list",
+                       f"--filter=name:{node_name}",
+                       "--format=json"]
+        output = subprocess.run(search_args, capture_output=True)
+
+        if output.returncode != 0:
+            raise Exception(f"check for existing {node_name} failed with exit code {output.returncode}")
+
+        return json.loads(output.stdout) != []
+
+    def __wait_rabbitmq_ready(self, node_name, attempts = 10):
+        ping_args = ["gcloud", "compute", "ssh",
+                     node_name,
+                     "--",
+                     "docker exec $(docker container ls | awk '/rabbitmq/ { print $1 }') rabbitmq-diagnostics ping -q"]
+        result = subprocess.run(ping_args)
+        if result.returncode == 0:
+            return
+        if attempts - 1 == 0:
+            raise Exception(f"timed out waiting for {node_name} to be ready")
+
+        console_out(self.actor, f"{node_name} did not respond to ping, will retry in 30s")
+        time.sleep(30)
+        self.__wait_rabbitmq_ready(node_name, attempts - 1)
+
+    def __deploy_rmq_node(self, node_name, common_conf, unique_conf):
+        console_out(self.actor, f"Deploying node {node_name}...")
+
+        disk_name = f"{node_name}-persistent"
+
+        create_disk_args = f"name={disk_name},"
+        f"size={unique_conf.volume_size}GB,"
+        f"type={unique_conf.volume},"
+        f"auto-delete=yes"
+
+        command_args = ["gcloud", "compute", "instances", "create-with-container",
+                        node_name,
+                        f"--public-dns",
+                        f"--boot-disk-type=pd-ssd",
+                        f"--labels=namespace={common_conf.run_tag}",
+                        f"--container-stdin",
+                        f"--container-tty",
+                        f"--preemptible",
+                        f"--machine-type={unique_conf.machine_type}",
+                        f"--create-disk={create_disk_args}",
+                        f"--container-mount-disk=name={disk_name},mount-path=/var/lib/rabbitmq",
+                        f"--container-env=RABBITMQ_ERLANG_COOKIE={common_conf.run_tag}",
+                        f"--container-env=RABBITMQ_DEFAULT_USER={common_conf.username}",
+                        f"--container-env=RABBITMQ_DEFAULT_PASS={common_conf.password}",
+                        f"--container-env=RABBITMQ_NODENAME=rabbit@{node_name}.c.{common_conf.gcp_project_id}.internal",
+                        f"--container-env=RABBITMQ_USE_LONGNAME=true",
+                        f"--container-image={unique_conf.container_image}"]
+
+        if unique_conf.container_env:
+            command_args.append(f"--container-env={unique_conf.container_env}")
+
+        exit_code = subprocess.call(command_args)
+
+        if exit_code != 0:
+            raise Exception(f"deploy {node_name} failed with exit code {exit_code}")
+
+    def __deploy_loadgen_node(self, node_name, common_conf):
+        console_out(self.actor, f"Deploying node {node_name}...")
+
+        default_scopes = ["https://www.googleapis.com/auth/devstorage.read_only",
+                          "https://www.googleapis.com/auth/logging.write",
+                          "https://www.googleapis.com/auth/monitoring.write",
+                          "https://www.googleapis.com/auth/pubsub",
+                          "https://www.googleapis.com/auth/service.management.readonly",
+                          "https://www.googleapis.com/auth/servicecontrol",
+                          "https://www.googleapis.com/auth/trace.append"]
+
+        sql_proxy_scopes = ["https://www.googleapis.com/auth/sqlservice.admin",
+                            "https://www.googleapis.com/auth/devstorage.read_write"]
+
+        scopes = ",".join(default_scopes + sql_proxy_scopes)
+
+        command_args = ["gcloud", "compute", "instances", "create-with-container",
+                        node_name,
+                        f"--public-dns",
+                        f"--boot-disk-type=pd-ssd",
+                        f"--labels=namespace={common_conf.run_tag}",
+                        f"--container-stdin",
+                        f"--container-tty",
+                        f"--preemptible",
+                        f"--scopes={scopes}",
+                        f"--machine-type={common_conf.loadgen_machine_type}",
+                        f"--container-image={common_conf.loadgen_container_image}"]
+
+        exit_code = subprocess.call(command_args)
+
+        if exit_code != 0:
+            raise Exception(f"deploy {node_name} failed with exit code {exit_code}")
+
+        console_out(self.actor, f"Waiting 1 minute to let the loadgen instance start...")
+        time.sleep(60)
+
+        if common_conf.gcp_postgres_connection_name:
+            console_out(self.actor, f"Starting cloud_sql_proxy on the loadgen instance...")
+            proxy_args = ["gcloud", "compute", "ssh",
+                          node_name,
+                          "--",
+                          "docker run -d "
+                          "-p 127.0.0.1:5432:5432 "
+                          "gcr.io/cloudsql-docker/gce-proxy:1.16 "
+                          "/cloud_sql_proxy "
+                          f"-instances={common_conf.gcp_postgres_connection_name}=tcp:0.0.0.0:5432"]
+            subprocess.call(proxy_args)
+            if exit_code != 0:
+                raise Exception(f"cloud_sql_proxy on {node_name} failed with exit code {exit_code}")

--- a/orchestration/run/GcpRunner.py
+++ b/orchestration/run/GcpRunner.py
@@ -1,0 +1,100 @@
+import subprocess
+
+from Runner import Runner
+from printer import console_out
+
+
+class GcpRunner(Runner):
+    def __init__(self):
+        super().__init__()
+
+    def run_benchmark(self, unique_conf, common_conf, playlist_entry, policies, run_ordinal):
+        status_id = unique_conf.technology + unique_conf.node_number
+
+        first_node_number = int(unique_conf.node_number)
+        cluster_size = int(unique_conf.cluster_size)
+        hosts = [f"{common_conf.run_tag}-rmq{i}-server.c.{common_conf.gcp_project_id}.internal" for i in
+                 range(first_node_number, first_node_number + cluster_size)]
+        nodes = ",".join([f"rabbit@{host}" for host in hosts])
+        broker_hosts = ",".join([f"{host}:5672" for host in hosts])
+
+        command_args = ["gcloud", "compute", "ssh",
+                        f"{common_conf.run_tag}-{unique_conf.suffix}-loadgen",
+                        "--",
+                        "docker exec $(docker container ls | awk '/rabbittesttool/ { print $1 }') "
+                        f"java -Xms1024m -Xmx8192m -jar rabbittesttool.jar "
+                        f"--mode {common_conf.mode} "
+                        f"--topology \"./topologies/{playlist_entry.topology}\" "
+                        f"--policies \"./policies/{policies}\" "
+                        f"--run-id {common_conf.run_id} "
+                        f"--run-tag {common_conf.run_tag} "
+                        f"--technology {unique_conf.technology} "
+                        f"--nodes {nodes} "
+                        f"--version {unique_conf.broker_version} "
+                        f"--instance {unique_conf.machine_type} "
+                        f"--volume {unique_conf.volume} "
+                        f"--filesystem {unique_conf.filesystem} "
+                        f"--hosting {common_conf.hosting} "
+                        f"--tenancy {unique_conf.tenancy} "
+                        f"--core-count {unique_conf.core_count} "
+                        f"--threads-per-core {unique_conf.threads_per_core} "
+                        f"--no-tcp-delay {unique_conf.no_tcp_delay} "
+                        f"--config-tag {unique_conf.config_tag} "
+                        f"--broker-hosts {broker_hosts} "
+                        f"--broker-mgmt-port 15672 "
+                        f"--broker-user {common_conf.username} "
+                        f"--broker-password {common_conf.password} "
+                        f"--postgres-jdbc-url \"{common_conf.postgres_url}\" "
+                        f"--postgres-user \"{common_conf.postgres_user}\" "
+                        f"--postgres-pwd \"{common_conf.postgres_pwd}\" "
+                        f"--override-step-seconds {common_conf.override_step_seconds} "
+                        f"--override-step-repeat {common_conf.override_step_repeat} "
+                        f"--override-step-msg-limit {common_conf.override_step_msg_limit} "
+                        f"--pub-connect-to-node {unique_conf.pub_connect_to_node} "
+                        f"--con-connect-to-node {unique_conf.con_connect_to_node} "
+                        f"--grace-period-sec {playlist_entry.grace_period_sec} "
+                        f"--run-ordinal {run_ordinal} "
+                        f"--benchmark-tags {common_conf.tags} "
+                        f"{playlist_entry.get_topology_variables()} "
+                        f"{playlist_entry.get_policy_variables()}"]
+
+        exit_code = subprocess.call(command_args)
+
+        if exit_code != 0:
+            console_out(self.actor, f"Benchmark {unique_conf.node_number} failed")
+            self._benchmark_status[status_id] = "failed"
+        else:
+            self._benchmark_status[status_id] = "success"
+
+    def run_background_load(self, unique_conf, common_conf):
+        console_out(self.actor, f"Starting background load for {unique_conf.node_number}")
+        status_id = unique_conf.technology + unique_conf.node_number
+        self._benchmark_status[status_id] = "started"
+
+        first_node_number = int(unique_conf.node_number)
+        cluster_size = int(unique_conf.cluster_size)
+        hosts = [f"{common_conf.run_tag}-rmq{i}-server.c.{common_conf.gcp_project_id}.internal" for i in
+                 range(first_node_number, first_node_number + cluster_size)]
+        nodes = ",".join([f"rabbit@{host}" for host in hosts])
+        broker_hosts = ",".join([f"{host}:5672" for host in hosts])
+
+        command_args = ["gcloud", "compute", "ssh",
+                        f"{common_conf.run_tag}-{unique_conf.suffix}-loadgen",
+                        "--",
+                        "docker exec $(docker container ls | awk '/rabbittesttool/ { print $1 }') "
+                        f"java -Xms1024m -Xmx8192m -jar rabbittesttool.jar "
+                        f"--mode benchmark "
+                        f"--topology \"./topologies/{common_conf.background_topology_file}\" "
+                        f"--policies \"./policies/{common_conf.background_policies_file}\" "
+                        f"--technology {unique_conf.technology} "
+                        f"--nodes {nodes} "
+                        f"--version {unique_conf.broker_version} "
+                        f"--broker-hosts {broker_hosts} "
+                        f"--broker-mgmt-port 15672 "
+                        f"--broker-user {common_conf.username} "
+                        f"--broker-password {common_conf.password} "
+                        f"--broker-vhost benchmark "
+                        f"--override-step-seconds {common_conf.background_step_seconds} "
+                        f"--override-step-repeat {common_conf.background_step_repeat}"]
+
+        subprocess.call(command_args)

--- a/orchestration/run/GcpUniqueConfiguration.py
+++ b/orchestration/run/GcpUniqueConfiguration.py
@@ -1,0 +1,11 @@
+from UniqueConfiguration import UniqueConfiguration
+from command_args import get_args, get_optional_arg, get_mandatory_arg, get_mandatory_arg_no_print, is_true, get_mandatory_arg_validated, get_optional_arg_validated
+
+class GcpUniqueConfiguration(UniqueConfiguration):
+    def __init__(self, args, suffix):
+        super().__init__(args, suffix)
+
+        self.container_image = get_mandatory_arg(args, "--container-image", self.suffix)
+        self.container_env = get_optional_arg(args, "--container-env", self.suffix, "")
+        self.machine_type = get_mandatory_arg(args, "--machine-type", self.suffix)
+        self.volume = get_mandatory_arg_validated(args, "--volume", self.suffix, ["pd-ssd", "standard"])

--- a/orchestration/run/Runner.py
+++ b/orchestration/run/Runner.py
@@ -20,62 +20,7 @@ class Runner:
         return self._benchmark_status[status_id]
     
     def run_benchmark(self, unique_conf, common_conf, playlist_entry, policies, run_ordinal):
-        status_id = unique_conf.technology + unique_conf.node_number
-
-        nodes = ""
-        for x in range(int(unique_conf.cluster_size)):
-            comma = ","
-            if x == 0:
-                comma = ""
-
-            node_number = int(unique_conf.node_number) + x
-            nodes = f"{nodes}{comma}rabbit@rabbitmq{node_number}"
-
-        self._benchmark_status[status_id] = "started"
-        exit_code = subprocess.call(["bash", "run-logged-aws-benchmark.sh", 
-                                unique_conf.node_number, 
-                                common_conf.key_pair, 
-                                unique_conf.technology, 
-                                unique_conf.broker_version, 
-                                unique_conf.instance, 
-                                unique_conf.volume, 
-                                unique_conf.filesystem, 
-                                common_conf.hosting, 
-                                unique_conf.tenancy, 
-                                common_conf.password, 
-                                common_conf.postgres_url, 
-                                common_conf.postgres_user, 
-                                common_conf.postgres_pwd, 
-                                playlist_entry.topology, 
-                                common_conf.run_id, 
-                                common_conf.username, 
-                                common_conf.password, 
-                                common_conf.run_tag, 
-                                unique_conf.core_count, 
-                                unique_conf.threads_per_core, 
-                                unique_conf.config_tag, 
-                                str(unique_conf.cluster_size), 
-                                unique_conf.no_tcp_delay, 
-                                policies, 
-                                str(common_conf.override_step_seconds), 
-                                str(common_conf.override_step_repeat), 
-                                nodes, 
-                                str(common_conf.override_step_msg_limit), 
-                                common_conf.override_broker_hosts, 
-                                unique_conf.pub_connect_to_node,
-                                unique_conf.con_connect_to_node,
-                                common_conf.mode,
-                                str(playlist_entry.grace_period_sec),
-                                str(run_ordinal),
-                                common_conf.tags,
-                                playlist_entry.get_topology_variables(),
-                                playlist_entry.get_policy_variables()])
-
-        if exit_code != 0:
-            console_out(self.actor, f"Benchmark {unique_conf.node_number} failed")
-            self._benchmark_status[status_id] = "failed"
-        else:
-            self._benchmark_status[status_id] = "success"
+        raise NotImplementedError
 
     def run_background_load_across_runs(self, configurations, common_conf):
         bg_threads = list()
@@ -96,37 +41,4 @@ class Runner:
         time.sleep(common_conf.background_delay)
 
     def run_background_load(self, unique_conf, common_conf):
-        console_out(self.actor, f"Starting background load for {unique_conf.node_number}")
-        status_id = unique_conf.technology + unique_conf.node_number
-
-        broker_user = "benchmark"
-        broker_password = common_conf.password
-        topology = common_conf.background_topology_file
-        policies = common_conf.background_policies_file
-        step_seconds = str(common_conf.background_step_seconds)
-        step_repeat = str(common_conf.background_step_repeat)
-
-        nodes = ""
-        for x in range(int(unique_conf.cluster_size)):
-            comma = ","
-            if x == 0:
-                comma = ""
-
-            node_number = int(unique_conf.node_number) + x
-            nodes = f"{nodes}{comma}{node_number}"
-
-        self._benchmark_status[status_id] = "started"
-        subprocess.Popen(["bash", "run-background-load-aws.sh", 
-                        broker_user, 
-                        broker_password, 
-                        str(unique_conf.cluster_size), 
-                        common_conf.key_pair, 
-                        unique_conf.node_number, 
-                        nodes, 
-                        policies, 
-                        step_seconds, 
-                        step_repeat, 
-                        common_conf.run_tag, 
-                        unique_conf.technology, 
-                        topology, 
-                        unique_conf.broker_version])
+        raise NotImplementedError

--- a/orchestration/run/UniqueConfiguration.py
+++ b/orchestration/run/UniqueConfiguration.py
@@ -3,13 +3,10 @@ from command_args import get_args, get_optional_arg, get_mandatory_arg, get_mand
 class UniqueConfiguration:
     def __init__(self, args, suffix):
         self.suffix = suffix
-        self.config_tag  = get_mandatory_arg(args, "--config-tag", self.suffix)
-        self.generic_unix_url  = get_mandatory_arg(args, "--generic-unix-url", self.suffix)
+        self.config_tag = get_mandatory_arg(args, "--config-tag", self.suffix)
         self.technology = get_mandatory_arg_validated(args, "--technology", self.suffix, ["rabbitmq"])
         self.cluster_size = int(get_optional_arg(args, "--cluster-size", self.suffix, "1"))
         self.broker_version = get_mandatory_arg(args, "--version", self.suffix)
-        self.instance = get_mandatory_arg(args, "--instance", self.suffix)
-        self.volume = get_mandatory_arg_validated(args, "--volume", self.suffix, ["ebs-io1","ebs-st1","ebs-gp2","local-nvme"])
         self.volume_size = get_mandatory_arg(args, "--volume-size", self.suffix)
         self.filesystem = get_mandatory_arg_validated(args, "--filesystem", self.suffix, ["ext4", "xfs"])
         self.tenancy = get_mandatory_arg_validated(args, "--tenancy", self.suffix, ["default","dedicated"])

--- a/orchestration/run/command_args.py
+++ b/orchestration/run/command_args.py
@@ -7,7 +7,7 @@ def get_args(args):
     # read arguments from json file first
     while index < len(args):
         key = args[index]
-        if key == "--aws-config-file":
+        if key == "--aws-config-file" or key == "--gcp-config-file":
             config_file = args[index+1]
             with open(config_file, encoding='utf-8-sig') as json_file:
                 text = json_file.read()

--- a/orchestration/run/run-logged-gcp-playlist.py
+++ b/orchestration/run/run-logged-gcp-playlist.py
@@ -7,11 +7,11 @@ import os.path
 import json
 from random import randint
 from command_args import get_args
-from AwsDeployer import AwsDeployer
-from AwsRunner import AwsRunner
-from AwsBrokerActions import AwsBrokerActions
-from AwsUniqueConfiguration import AwsUniqueConfiguration
-from AwsCommonConfiguration import AwsCommonConfiguration
+from GcpDeployer import GcpDeployer
+from GcpRunner import GcpRunner
+from GcpBrokerActions import GcpBrokerActions
+from GcpUniqueConfiguration import GcpUniqueConfiguration
+from GcpCommonConfiguration import GcpCommonConfiguration
 from PlaylistEntry import PlaylistEntry
 from printer import console_out
 
@@ -89,7 +89,7 @@ def get_playlist_entries(playlist_file):
     return playlist_entries
 
 args = get_args(sys.argv)
-common_conf = AwsCommonConfiguration(args)
+common_conf = GcpCommonConfiguration(args)
 
 console_out("RUNNER", f"RUN ID = {common_conf.run_id}")
 
@@ -102,7 +102,7 @@ for config_number in range(1, common_conf.config_count+1):
     unique_conf_list = list()
     for _ in range(common_conf.parallel_count):
         node_number = common_conf.node_counter
-        unique_conf = AwsUniqueConfiguration(args, str(config_number))
+        unique_conf = GcpUniqueConfiguration(args, str(config_number))
         unique_conf.set_node_number(str(node_number))
 
         if unique_conf.policies_file != "none" and not os.path.exists("../deploy/policies/" + unique_conf.policies_file):
@@ -124,9 +124,9 @@ playlist_entries = get_playlist_entries(common_conf.playlist_file)
 
 console_out("RUNNER", f"{len(playlist_entries)} entries in {common_conf.playlist_file} playlist")
 
-runner = AwsRunner()
-deployer = AwsDeployer()
-broker_actions = AwsBrokerActions(deployer)
+runner = GcpRunner()
+deployer = GcpDeployer()
+broker_actions = GcpBrokerActions(deployer)
 
 if len(playlist_entries) == 0:
     console_out("RUNNER", "No playlist entries to run")
@@ -210,7 +210,7 @@ for i in range(common_conf.repeat_count):
                 status_id1 = unique_conf.technology + unique_conf.node_number
                 if runner.get_benchmark_status(status_id1) != "success":
                     console_out("RUNNER", f"Benchmark failed for node {unique_conf.node_number} and topology {entry.topology}")
-                    deployer.teardown_all(configurations, common_conf.key_pair, common_conf, common_conf.no_destroy)
+                    deployer.teardown_all(configurations, common_conf, common_conf.no_destroy)
                     exit(1)
 
         # wait for configuration gap seconds


### PR DESCRIPTION
add `run-logged-gcp-playlist.py` and make supporting changes to
allow use of playlists on Google Cloud Platform.
The rabbitmq broker release is specified as a Docker image, rather
than via generic unix url used in AWS.

Limitations:
- unlike AWS, influxDB is not yet supported